### PR TITLE
Implement accounts filters

### DIFF
--- a/app/accounts/page.tsx
+++ b/app/accounts/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react'
 import AccountsTable, { AccountsTableRef } from './table/AccountsTable'
-import { Account, AccountFilters, AccountData } from '@/interface/Account'
+import { Account, AccountFilters } from '@/interface/Account'
 import { useLazyFetch } from '@/utils/useFetch'
 import {
   FloatButton,
@@ -24,15 +24,22 @@ import {
   faSliders
 } from '@fortawesome/free-solid-svg-icons'
 import FiltersForm from './table/FiltersForm'
+import AccountModel from '@/model/Account'
 
-interface Props {
-  filters: AccountFilters
-  onChangeFilters: (filters: AccountFilters) => void
-  onCreate: () => void
-  tableData: AccountData | null
+const DEFAULT_FILTERS: AccountFilters = {
+  page: 1,
+  pageSize: 10,
+  search: '',
+  is_deleted: false,
+  order: 'expiration ASC'
 }
 
-const Accounts = ({ onCreate, onChangeFilters, filters, tableData }: Props) => {
+const Accounts = () => {
+  const [filters, setFilters] = useState<AccountFilters>(DEFAULT_FILTERS)
+  const onChangeFilters = (newFilters: AccountFilters) => {
+    setFilters(newFilters)
+    AccountsTableRef.current?.setFilters(newFilters)
+  }
   const [timer, setTimer] = useState<any | null>(null)
 
   const onChangeToolbarFilters = (filters: AccountFilters) => {
@@ -137,7 +144,12 @@ const Accounts = ({ onCreate, onChangeFilters, filters, tableData }: Props) => {
           allowClear
           style={{ flex: 1, marginRight: '8px' }}
         />
-        <Badge size='small' style={{ color: 'white' }} color='#5A54F9'>
+        <Badge
+          size='small'
+          style={{ color: 'white' }}
+          count={AccountModel.countActiveFilters(filters)}
+          color='#5A54F9'
+        >
           <Button shape='circle' onClick={openFilters}>
             <FontAwesomeIcon icon={faSliders} />
           </Button>

--- a/app/accounts/table/FiltersForm.tsx
+++ b/app/accounts/table/FiltersForm.tsx
@@ -1,12 +1,12 @@
 import RemoteCombobox from '@/components/RemoteCombobox'
-import { SharedBoardAccountFilters } from '@/interface/SharedBoard'
+import { AccountFilters } from '@/interface/Account'
 import { faFilter } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button, Col, DatePicker, Form, Select } from 'antd'
 
 interface Props {
-  currentFilters: SharedBoardAccountFilters
-  onChangeFilters: (filters: SharedBoardAccountFilters) => void
+  currentFilters: AccountFilters
+  onChangeFilters: (filters: AccountFilters) => void
   onClose: () => void
 }
 

--- a/model/Account.ts
+++ b/model/Account.ts
@@ -1,5 +1,5 @@
 'use client'
-import { Account } from '@/interface/Account'
+import { Account, AccountFilters } from '@/interface/Account'
 import { decryptValue, encryptValue } from '@/utils/cryptoHooks'
 import dayjs from 'dayjs'
 
@@ -20,6 +20,25 @@ class AccountModel {
       service: record ? [{ label: record.service.name, value: record.serviceId }] : undefined,
       password: record ? decryptValue(record.password) : undefined
     }
+  }
+
+  static transformFiltersToUrl: (filters: AccountFilters) => string = (filters) => {
+    const beginDate = filters.expiration_range?.[0] ? dayjs(filters.expiration_range[0]).format('YYYY-MM-DD') : ''
+    const endDate = filters.expiration_range?.[1] ? dayjs(filters.expiration_range[1]).format('YYYY-MM-DD') : ''
+    const url = `?page=${filters.page}&limit=${filters.pageSize}&search=${filters.search}` +
+      `&is_deleted=${filters.is_deleted === undefined ? '' : filters.is_deleted}` +
+      `&begin_date=${beginDate}&end_date=${endDate}` +
+      `&service=${filters.service?.map(({ value }) => value) ?? ''}` +
+      `&order=${filters.order ?? ''}`
+    return url
+  }
+
+  static countActiveFilters (filters: AccountFilters) {
+    let count = 0
+    if (filters.expiration_range?.length) count++
+    if (filters.is_deleted !== undefined) count++
+    if (filters.service?.length) count++
+    return count
   }
 }
 


### PR DESCRIPTION
## Summary
- add URL transform and filter count helpers to `AccountModel`
- update accounts table to send filter params
- update filter form types for accounts
- add local filter management in accounts page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686167739c3c832698c4f8cb72dcefc7