### PR TITLE
Add reusable URL state hook and persist sharedBoards filters

### DIFF
--- a/app/sharedBoards/[id]/table/Table.tsx
+++ b/app/sharedBoards/[id]/table/Table.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState
 } from 'react'
+import useUrlState from '@/utils/useUrlState'
 import { TableColumns } from './TableColumns'
 import ContextMenu from './ContextMenu'
 import { Account } from '@/interface/Account'
@@ -66,10 +67,13 @@ const AccountsTable = forwardRef<SharedBoardsTableRef, Props>(
       loading,
       fetchApiData: getData
     } = useLazyFetch<SharedBoardAccountsData>()
+    const [filtersInUrl, setFiltersInUrl] =
+      useUrlState<SharedBoardAccountFilters>('filters', DEFAULT_FILTERS)
     const [localFilters, setLocalFilters] =
-      useState<SharedBoardAccountFilters>(DEFAULT_FILTERS)
-    const applyFilters = (filters = localFilters) => {
+      useState<SharedBoardAccountFilters>(filtersInUrl)
+    const applyFilters = (filters: SharedBoardAccountFilters = localFilters) => {
       setLocalFilters(filters)
+      setFiltersInUrl(filters)
       getData(
         `sharedBoards/accounts/${sharedBoardId}${SharedBoardModel.transformFilterToUrl(filters)}`,
         'GET'
@@ -167,9 +171,14 @@ const AccountsTable = forwardRef<SharedBoardsTableRef, Props>(
     }
 
     useEffect(() => {
-      applyFilters()
+      setLocalFilters(filtersInUrl)
+      applyFilters(filtersInUrl)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
+
+    useEffect(() => {
+      setLocalFilters(filtersInUrl)
+    }, [filtersInUrl])
     return (
       <>
         <Toolbar tableData={data} onCreate={createAccount} onChangeFilters={applyFilters} filters={localFilters} />

--- a/utils/useUrlState.ts
+++ b/utils/useUrlState.ts
@@ -1,0 +1,41 @@
+'use client'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useMemo } from 'react'
+
+function parseParam<T> (value: string | null, defaultValue: T): T {
+  if (!value) return defaultValue
+  try {
+    return JSON.parse(decodeURIComponent(value)) as T
+  } catch (e) {
+    return defaultValue
+  }
+}
+
+export function useUrlState<T extends object> (key: string, defaultValue: T) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const value = useMemo(() => {
+    return parseParam<T>(searchParams.get(key), defaultValue)
+  }, [searchParams, key, defaultValue])
+
+  const setValue = useCallback(
+    (val: T) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set(key, encodeURIComponent(JSON.stringify(val)))
+      router.replace(`${pathname}?${params.toString()}`)
+    },
+    [searchParams, key, router, pathname]
+  )
+
+  const remove = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete(key)
+    router.replace(`${pathname}?${params.toString()}`)
+  }, [searchParams, key, router, pathname])
+
+  return [value, setValue, remove] as const
+}
+
+export default useUrlState


### PR DESCRIPTION
## Summary
- add `useUrlState` hook to store objects as query params
- persist sharedBoards account filters in the URL using the new hook

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68616f779f808326b137520a3a70b15d