### PR TITLE
Persist accounts table filters

### DIFF
--- a/app/accounts/page.tsx
+++ b/app/accounts/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import dayjs from 'dayjs'
 import AccountsTable, { AccountsTableRef } from './table/AccountsTable'
 import { Account, AccountFilters } from '@/interface/Account'
@@ -26,6 +26,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import FiltersForm from './table/FiltersForm'
 import AccountModel from '@/model/Account'
+import useUrlFilters from '@/utils/useUrlFilters'
 
 const DEFAULT_FILTERS: AccountFilters = {
   page: 1,
@@ -37,11 +38,24 @@ const DEFAULT_FILTERS: AccountFilters = {
 }
 
 const Accounts = () => {
-  const [filters, setFilters] = useState<AccountFilters>(DEFAULT_FILTERS)
+  const [filtersInUrl, setFiltersInUrl] =
+    useUrlFilters<AccountFilters>('filters', DEFAULT_FILTERS)
+  const [filters, setFilters] = useState<AccountFilters>(filtersInUrl)
   const onChangeFilters = (newFilters: AccountFilters) => {
     setFilters(newFilters)
+    setFiltersInUrl(newFilters)
     AccountsTableRef.current?.setFilters(newFilters)
   }
+  const onTableFiltersChange = (newFilters: AccountFilters) => {
+    setFilters(newFilters)
+    setFiltersInUrl(newFilters)
+  }
+
+  useEffect(() => {
+    setFilters(filtersInUrl)
+    AccountsTableRef.current?.setFilters(filtersInUrl)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtersInUrl])
   const [timer, setTimer] = useState<any | null>(null)
 
   const onChangeToolbarFilters = (filters: AccountFilters) => {
@@ -143,6 +157,7 @@ const Accounts = () => {
       >
         <Input.Search
           onChange={e => handleSearchChange(e.target.value)}
+          value={filters.search}
           allowClear
           style={{ flex: 1, marginRight: '8px' }}
         />
@@ -162,6 +177,7 @@ const Accounts = () => {
         onEdit={onEdit}
         onDelete={onDelete}
         onRenew={openRenew}
+        onFiltersChange={onTableFiltersChange}
       />
       <FloatButton.Group
         trigger='click'

--- a/app/accounts/table/AccountsTable.tsx
+++ b/app/accounts/table/AccountsTable.tsx
@@ -23,6 +23,7 @@ interface Props {
   onEdit: (record: Account) => void
   onDelete: (record: Account) => void
   onRenew: (record: Account) => void
+  onFiltersChange?: (filters: AccountFilters) => void
 }
 export interface AccountsTableRef {
   refresh: () => void
@@ -39,17 +40,18 @@ const DEFAULT_FILTERS: AccountFilters = {
 }
 
 const AccountsTable = forwardRef<AccountsTableRef, Props>(function SalesTable (
-  { onEdit, onDelete, onRenew },
+  { onEdit, onDelete, onRenew, onFiltersChange },
   ref
 ) {
   const { data, loading, fetchApiData: getData } = useLazyFetch<AccountData>()
   const [localFilters, setLocalFilters] = useState<AccountFilters>(DEFAULT_FILTERS)
-  const applyFilters = (filters: AccountFilters = localFilters) => {
-    setLocalFilters(filters)
-    getData(
-      `accounts${AccountModel.transformFiltersToUrl(filters)}`,
-      'GET'
-    ).catch(err =>
+const applyFilters = (filters: AccountFilters = localFilters) => {
+  setLocalFilters(filters)
+  onFiltersChange?.(filters)
+  getData(
+    `accounts${AccountModel.transformFiltersToUrl(filters)}`,
+    'GET'
+  ).catch(err =>
       notification.error({
         message: 'Algo salió mal',
         description: err.message


### PR DESCRIPTION
## Summary
- sync account filters with URL using `useUrlFilters`
- update `AccountsTable` to notify filter changes

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6863076ddc38832b8be97ab4f2138b2c